### PR TITLE
Bug fix when parent decides if a child is active

### DIFF
--- a/adminlte_full/menu.py
+++ b/adminlte_full/menu.py
@@ -52,7 +52,7 @@ class MenuItem(object):
 
     def has_active_child(self):
         for child in self.children:
-            if child.is_active:
+            if child.is_active():
                 return True
         return None
 


### PR DESCRIPTION
When rendering the final HTML menu, I saw that all parent items were active and expanded and after a debugging session I determined that there was a small bug: the expression "child.is_active" always returns True because the "is_active" method is defined. I fixed it by using the full method invocation syntax, which I think was your original intention.

Could you please accept this correction and publish a new version to PyPI?

Thanks!
